### PR TITLE
Add admin emails on 500 errors as a default logger

### DIFF
--- a/funfactory/log_settings.py
+++ b/funfactory/log_settings.py
@@ -51,7 +51,6 @@ cfg = {
         }
     },
     'loggers': {
-        'i': {},
         'django.request': {
             'handlers': ['mail_admins'],
             'level': 'ERROR',


### PR DESCRIPTION
Playdoh wipes out default logging settings, which causes playdoh apps to not send emails on 500 errors when DEV=False. This adds that setting back in so Playdoh apps send these emails by default.
