### PR TITLE
Ignore hidden directories (like .svn) in the locale folder

### DIFF
--- a/funfactory/settings_base.py
+++ b/funfactory/settings_base.py
@@ -69,7 +69,8 @@ LANGUAGE_CODE = 'en-US'
 try:
     DEV_LANGUAGES = [
         loc.replace('_', '-') for loc in os.listdir(path('locale'))
-        if os.path.isdir(path('locale', loc)) and loc != 'templates'
+        if (os.path.isdir(path('locale', loc)) and loc != 'templates'
+            and loc[0] != '.')
     ]
 except OSError:
     DEV_LANGUAGES = ('en-US',)


### PR DESCRIPTION
Fixes a KeyError (https://gist.github.com/ff25e123656b1cfc66a5) I ran into on Mozillians with a locale folder that had a hidden, but perfectly valid, `.svn` folder in it. I think it's sane to ignore any hidden folders in that directory. r?
