### PR TITLE
Make session cookies more secure

### DIFF
--- a/funfactory/manage.py
+++ b/funfactory/manage.py
@@ -105,6 +105,13 @@ def validate_settings(settings):
         else:
             raise ImproperlyConfigured(msg)
 
+    if getattr(settings, 'SESSION_COOKIE_SECURE', None) is None:
+        msg = ('settings.SESSION_COOKIE_SECURE should be set to True; '
+               'otherwise, your session ids can be intercepted over HTTP!')
+        if settings.DEBUG:
+            warnings.warn(msg)
+        else:
+            raise ImproperlyConfigured(msg)
 
 def _not_setup():
     raise EnvironmentError(

--- a/funfactory/settings_base.py
+++ b/funfactory/settings_base.py
@@ -230,6 +230,11 @@ INSTALLED_APPS = (
 # Path to Java. Used for compress_assets.
 JAVA_BIN = '/usr/bin/java'
 
+# Sessions
+#
+# By default, be at least somewhat secure with our session cookies.
+SESSION_COOKIE_HTTPONLY = True
+
 ## Auth
 PWD_ALGORITHM = 'sha512'  # recommended: 'bcrypt'
 HMAC_KEYS = {  # for bcrypt only

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -20,18 +20,40 @@ def teardown():
 @raises(UserWarning)
 @patch.object(settings, 'DEBUG', True)
 @patch.object(settings, 'SECRET_KEY', '')
+@patch.object(settings, 'SESSION_COOKIE_SECURE', True)
 def test_empty_secret_key_for_dev():
+    validate_settings(settings)
+
+
+@patch.object(settings, 'DEBUG', True)
+@patch.object(settings, 'SECRET_KEY', 'any random value')
+@patch.object(settings, 'SESSION_COOKIE_SECURE', False)
+def test_insecure_session_cookie_for_dev():
     validate_settings(settings)
 
 
 @raises(ImproperlyConfigured)
 @patch.object(settings, 'DEBUG', False)
 @patch.object(settings, 'SECRET_KEY', '')
+@patch.object(settings, 'SESSION_COOKIE_SECURE', True)
 def test_empty_secret_key_for_prod():
     validate_settings(settings)
 
 
 @patch.object(settings, 'DEBUG', False)
 @patch.object(settings, 'SECRET_KEY', 'any random value')
+@patch.object(settings, 'SESSION_COOKIE_SECURE', True)
 def test_secret_key_ok():
+    """Validate required security-related settings.
+
+    Don't raise exceptions when required settings are set properly."""
+    validate_settings(settings)
+
+
+@raises(ImproperlyConfigured)
+@patch.object(settings, 'DEBUG', False)
+@patch.object(settings, 'SECRET_KEY', 'any random value')
+@patch.object(settings, 'SESSION_COOKIE_SECURE', None)
+def test_session_cookie_ok():
+    """Raise an exception if session cookies aren't secure in production."""
     validate_settings(settings)


### PR DESCRIPTION
Enables HTTP Only by default and alerts/warns developers of
insecure session cookies.

After realizing that there was no warning to devs or sysadmins of a site not using secure session cookies (which we should all be doing, I'd wager), I figured this belonged in playdoh somewhere.
