### PR TITLE
Remove language code from admin interface.

### DIFF
--- a/funfactory/settings_base.py
+++ b/funfactory/settings_base.py
@@ -115,7 +115,7 @@ DOMAIN_METHODS = {
 }
 
 # Paths that don't require a locale code in the URL.
-SUPPORTED_NONLOCALES = ['media']
+SUPPORTED_NONLOCALES = ['media', 'admin']
 
 
 ## Media and templates.


### PR DESCRIPTION
I recently ran into an issue with affiliates where IT blacklisted /admin on production, but the locale prefix got around the blacklist. We typically don't localize the admin interface, so it'd be nice to have funfactory remove the locale prefix. 

Kitsune and Kuma already do this, so I figured it's common enough to include as a default.
