### PR TITLE
make it possible to disable arecibo to use Celery

### DIFF
--- a/funfactory/log.py
+++ b/funfactory/log.py
@@ -13,7 +13,10 @@ class AreciboHandler(logging.Handler):
         arecibo = getattr(settings, 'ARECIBO_SERVER_URL', '')
 
         if arecibo and hasattr(record, 'request'):
-            from django_arecibo.tasks import post
+            if getattr(settings, 'ARECIBO_USES_CELERY', False):
+                from django_arecibo.tasks import post
+            else:
+                from django_arecibo.wrapper import post
             post(record.request, 500)
 
 

--- a/funfactory/settings_base.py
+++ b/funfactory/settings_base.py
@@ -221,8 +221,8 @@ INSTALLED_APPS = (
     'jingo_minify',
     'tower',  # for ./manage.py extract (L10n)
     'cronjobs',  # for ./manage.py cron * cmd line tasks
-    
-    
+
+
     # Django contrib apps
     'django.contrib.auth',
     'django_sha2',  # Load after auth to monkey-patch it.
@@ -276,6 +276,10 @@ CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 # Time in seconds before celery.exceptions.SoftTimeLimitExceeded is raised.
 # The task can catch that and recover but should exit ASAP.
 CELERYD_TASK_SOFT_TIME_LIMIT = 60 * 2
+
+## Arecibo
+# when ARECIBO_SERVER_URL is set, it can use celery or the regular wrapper
+ARECIBO_USES_CELERY = True
 
 # For absolute urls
 try:


### PR DESCRIPTION
r?

Once this is landed, I'll update playdoh-lib, playdoh and playdoh-docs to highlight how to switch off celery for arecibo sending. 

I left it default to True so it doesn't break existing applications that have grown to depend on this. 
