### PR TITLE
BrowserID support (playdoh issue 73)

### DIFF
--- a/funfactory/requirements/prod.txt
+++ b/funfactory/requirements/prod.txt
@@ -3,6 +3,10 @@ Django==1.4
 -e git://github.com/jbalogh/django-multidb-router.git#egg=django-multidb-router
 -e git://github.com/jsocol/django-cronjobs.git#egg=django-cronjobs
 
+# BrowserID
+django-browserid==0.5.1
+requests==0.13.0
+
 # Forms
 -e git://github.com/mozilla/happyforms.git#egg=happyforms
 

--- a/funfactory/settings_base.py
+++ b/funfactory/settings_base.py
@@ -228,6 +228,7 @@ INSTALLED_APPS = (
     'jingo_minify',
     'tower',  # for ./manage.py extract (L10n)
     'cronjobs',  # for ./manage.py cron * cmd line tasks
+    'django_browserid',
 
 
     # Django contrib apps


### PR DESCRIPTION
Includes django-browserid (and requests) by default in new playdoh apps. Also enables django.contrib.staticfiles with basic settings, in order to make django-browserid's JS available.
