### PR TITLE
Update get_ functions

### DIFF
--- a/funfactory/settings_base.py
+++ b/funfactory/settings_base.py
@@ -8,6 +8,7 @@ from django.utils.functional import lazy
 
 from .manage import ROOT, path
 
+
 # For backwards compatability, (projects built based on cloning playdoh)
 # we still have to have a ROOT_URLCONF.
 # For new-style playdoh projects this will be overridden automatically
@@ -104,12 +105,14 @@ PROD_LANGUAGES = (
     'en-US',
 )
 
+
 def lazy_lang_url_map():
     from django.conf import settings
     langs = settings.DEV_LANGUAGES if settings.DEV else settings.PROD_LANGUAGES
     return dict([(i.lower(), i) for i in langs])
 
 LANGUAGE_URL_MAP = lazy(lazy_lang_url_map, dict)()
+
 
 # Override Django's built-in with our native names
 def lazy_langs():
@@ -184,6 +187,24 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     #'jingo_minify.helpers.build_ids',
 )
 
+
+def get_template_context_processors(exclude=(), append=(),
+                        current={'processors': TEMPLATE_CONTEXT_PROCESSORS}):
+    """
+    Returns TEMPLATE_CONTEXT_PROCESSORS without the processors listed in
+    exclude and with the processors listed in append.
+
+    The use of a mutable dict is intentional, in order to preserve the state of
+    the TEMPLATE_CONTEXT_PROCESSORS tuple across multiple settings files.
+    """
+
+    current['processors'] = tuple(
+        [p for p in current['processors'] if p not in exclude]
+    ) + tuple(append)
+
+    return current['processors']
+
+
 TEMPLATE_DIRS = (
     path('templates'),
 )
@@ -206,6 +227,7 @@ STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'compressor.finders.CompressorFinder',
 )
+
 
 def JINJA_CONFIG():
     import jinja2
@@ -241,6 +263,23 @@ MIDDLEWARE_CLASSES = (
     'mobility.middleware.XMobileMiddleware',
 )
 
+
+def get_middleware(exclude=(), append=(),
+                   current={'middleware': MIDDLEWARE_CLASSES}):
+    """
+    Returns MIDDLEWARE_CLASSES without the middlewares listed in exclude and
+    with the middlewares listed in append.
+
+    The use of a mutable dict is intentional, in order to preserve the state of
+    the MIDDLEWARE_CLASSES tuple across multiple settings files.
+    """
+
+    current['middleware'] = tuple(
+        [m for m in current['middleware'] if m not in exclude]
+    ) + tuple(append)
+    return current['middleware']
+
+
 INSTALLED_APPS = (
     # Local apps
     'funfactory',  # Content common to most playdoh-based apps.
@@ -272,6 +311,21 @@ INSTALLED_APPS = (
     # L10n
     'product_details',
 )
+
+
+def get_apps(exclude=(), append=(), current={'apps': INSTALLED_APPS}):
+    """
+    Returns INSTALLED_APPS without the apps listed in exclude and with the apps
+    listed in append.
+
+    The use of a mutable dict is intentional, in order to preserve the state of
+    the INSTALLED_APPS tuple across multiple settings files.
+    """
+
+    current['apps'] = tuple(
+        [a for a in current['apps'] if a not in exclude]
+    ) + tuple(append)
+    return current['apps']
 
 # Path to Java. Used for compress_assets.
 JAVA_BIN = '/usr/bin/java'

--- a/funfactory/utils.py
+++ b/funfactory/utils.py
@@ -2,7 +2,6 @@ import logging
 
 from django.conf import settings
 
-import settings_base
 
 log = logging.getLogger('funfactory')
 
@@ -22,31 +21,3 @@ def absolutify(url):
             site_url = ''.join(map(str, (protocol, hostname, ':', port)))
 
     return site_url + url
-
-
-def get_middleware(exclude):
-    """
-    Returns the default funfactory MIDDLEWARE_CLASSES list without the
-    middlewares listed in exclude.
-    """
-
-    return filter(lambda m: m not in exclude, settings_base.MIDDLEWARE_CLASSES)
-
-
-def get_apps(exclude):
-    """
-    Returns the default funfactory INSTALLED_APPS list without the apps
-    listed in exclude.
-    """
-
-    return filter(lambda a: a not in exclude, settings_base.INSTALLED_APPS)
-
-
-def get_template_context_processors(exclude):
-    """
-    Returns the default funfactory TEMPLATE_CONTEXT_PROCESSORS without the
-    processors listed in exclude.
-    """
-
-    return filter(lambda p: p not in exclude,
-        settings_base.TEMPLATE_CONTEXT_PROCESSORS)

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -26,21 +26,3 @@ class AbsolutifyTests(TestCase):
     def test_with_port(self):
         url = utils.absolutify(AbsolutifyTests.ABS_PATH)
         eq_('http://test.mo.com:8009/some/absolute/path', url)
-
-
-@patch.object(utils.settings_base, 'INSTALLED_APPS', ('one', 'two', 'three'))
-class GetAppsTests(TestCase):
-    def test_exclude(self):
-        eq_(utils.get_apps(exclude=['three']), ('one', 'two'))
-
-
-@patch.object(utils.settings_base, 'MIDDLEWARE_CLASSES', ('foo', 'bar', 'baz'))
-class GetMiddlewareTests(TestCase):
-    def test_exclude(self):
-        eq_(utils.get_middleware(exclude=['foo']), ('bar', 'baz'))
-
-
-@patch.object(utils.settings_base, 'TEMPLATE_CONTEXT_PROCESSORS', ('a', 'b'))
-class GetTemplateContextProcessorsTests(TestCase):
-    def test_exclude(self):
-        eq_(utils.get_template_context_processors(exclude=['a']), ('b',))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,9 +2,11 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 from mock import Mock, patch
-from nose.tools import raises
+from nose.tools import eq_, raises
 
 from funfactory.manage import validate_settings
+from funfactory.settings_base import (get_apps, get_middleware,
+    get_template_context_processors)
 
 
 @patch.object(settings, 'DEBUG', True)
@@ -59,3 +61,43 @@ def test_empty_hmac_in_dev():
 @patch.object(settings, 'SESSION_COOKIE_SECURE', False)
 def test_empty_hmac_in_prod():
     validate_settings(settings)
+
+
+def test_get_apps():
+    eq_(get_apps(exclude=('chico',),
+        current={'apps': ('groucho', 'harpo', 'chico')}),
+        ('groucho', 'harpo'))
+    eq_(get_apps(append=('zeppo',),
+        current={'apps': ('groucho', 'harpo', 'chico')}),
+        ('groucho', 'harpo', 'chico', 'zeppo'))
+    eq_(get_apps(exclude=('harpo', 'zeppo'), append=('chico',),
+        current={'apps': ('groucho', 'harpo', 'zeppo')}),
+        ('groucho', 'chico'))
+    eq_(get_apps(exclude=('funfactory'), append=('gummo',)), get_apps())
+
+
+def test_get_middleware():
+    eq_(get_middleware(exclude=['larry', 'moe'],
+        current={'middleware': ('larry', 'curly', 'moe')}),
+        ('curly',))
+    eq_(get_middleware(append=('shemp', 'moe'),
+        current={'middleware': ('larry', 'curly')}),
+        ('larry', 'curly', 'shemp', 'moe'))
+    eq_(get_middleware(exclude=('curly'), append=['moe'],
+        current={'middleware': ('shemp', 'curly', 'larry')}),
+        ('shemp', 'larry', 'moe'))
+    eq_(get_middleware(append=['emil']), get_middleware())
+
+
+def test_get_processors():
+    eq_(get_template_context_processors(exclude=('aramis'),
+        current={'processors': ('athos', 'porthos', 'aramis')}),
+        ('athos', 'porthos'))
+    eq_(get_template_context_processors(append=("d'artagnan",),
+        current={'processors': ('athos', 'porthos')}),
+        ('athos', 'porthos', "d'artagnan"))
+    eq_(get_template_context_processors(exclude=['athos'], append=['aramis'],
+        current={'processors': ('athos', 'porthos', "d'artagnan")}),
+        ('porthos', "d'artagnan", 'aramis'))
+    eq_(get_template_context_processors(append=['richelieu']),
+        get_template_context_processors())


### PR DESCRIPTION
Now the various settings-related `get_` functions take both an `exclude` and `append` arguments, work correctly with no arguments, and persist their current values across playdoh's `settings/base.py` and `settings/local.py`.
