### PR TITLE
Use HTTPS session cookies by default.

### DIFF
--- a/funfactory/settings_base.py
+++ b/funfactory/settings_base.py
@@ -334,6 +334,7 @@ JAVA_BIN = '/usr/bin/java'
 #
 # By default, be at least somewhat secure with our session cookies.
 SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SECURE = True
 
 ## Auth
 # The first hasher in this list will be used for new passwords.


### PR DESCRIPTION
Turns on secure session cookies by default. This is balanced by a
commented line in playdoh's local.py-dist that warns developers
that local instances without HTTPS should disable this.
