### PR TITLE
[DO NOT MERGE] Fix branch reference for Django.

### DIFF
--- a/funfactory/requirements/prod.txt
+++ b/funfactory/requirements/prod.txt
@@ -1,5 +1,5 @@
 # Django stuff
--e git://github.com/django/django@1.3.X#egg=django
+-e git://github.com/django/django@1.3.2#egg=django
 -e git://github.com/jbalogh/django-multidb-router.git#egg=django-multidb-router
 
 # Forms


### PR DESCRIPTION
Since Django switched to Github, all their tags broke and there
isn't a 1.3.X tag anymore. This fix allows sites that are still
on funfactory 1.0 for whatever reason to not break when pulling
in django via pip (some Affiliates contributors have run into this
issue).

Instead of merging this, I'm proposing to add this branch and move the 1.0 tag to it as it is just a fix for sites still on the old funfactory version (like Affiliates, which will upgrade soon).
