### PR TITLE
Add billiard to compiled requirements

### DIFF
--- a/funfactory/requirements/compiled.txt
+++ b/funfactory/requirements/compiled.txt
@@ -3,3 +3,6 @@ Jinja2==2.5.5
 
 # for bcrypt passwords
 py-bcrypt==0.2
+
+# used by celery 3.0
+billiard==2.7.3


### PR DESCRIPTION
billiard is required by celery 3.0.9.

playdoh-lib includes funfactory, so I think I need to land this before I can
update celery.

r?
