### PR TITLE
Ensure that reverse returns a str object and add reverse_lazy.

### DIFF
--- a/funfactory/urlresolvers.py
+++ b/funfactory/urlresolvers.py
@@ -2,6 +2,8 @@ from threading import local
 
 from django.conf import settings
 from django.core.urlresolvers import reverse as django_reverse
+from django.utils.encoding import iri_to_uri
+from django.utils.functional import lazy
 from django.utils.translation.trans_real import parse_accept_lang_header
 
 
@@ -27,9 +29,13 @@ def reverse(viewname, urlconf=None, args=None, kwargs=None, prefix=None):
         prefix = prefix or '/'
     url = django_reverse(viewname, urlconf, args, kwargs, prefix)
     if prefixer:
-        return prefixer.fix(url)
-    else:
-        return url
+        url = prefixer.fix(url)
+
+    # Ensure any unicode characters in the URL are escaped.
+    return iri_to_uri(url)
+
+
+reverse_lazy = lazy(reverse, str)
 
 
 def find_supported(test):


### PR DESCRIPTION
Certain parts of Django assume that URLs are str objects (as URLs are
ASCII-only) and break if given a unicode object. In many cases reverse
will return a unicode object because it builds URLs using 
`request.META['SCRIPT_NAME']`, which is a unicode string.

To handle this and any other situation involving unicode in a URL, we 
should use Django's `iri_to_uri` function to escape all unicode in the URL 
and return a str object.

Also adds reverse_lazy, which makes using reverse in decorators and 
settings files easier.
