### PR TITLE
Move to py-bcrypt 0.3.

### DIFF
--- a/funfactory/requirements/compiled.txt
+++ b/funfactory/requirements/compiled.txt
@@ -2,4 +2,4 @@ MySQL-python==1.2.3c1
 Jinja2==2.5.5
 
 # for bcrypt passwords
-py-bcrypt==0.2
+py-bcrypt==0.3


### PR DESCRIPTION
py-bcrypt 0.2 has a security problem, and has been pulled from PyPI. See https://code.google.com/p/py-bcrypt/source/detail?r=3bc365ff43736d26ff37e9f2a4084f37b381b569 for details.
