### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ settings.
     :target: https://travis-ci.org/mozilla/funfactory
 .. image:: https://coveralls.io/repos/mozilla/funfactory/badge.png?branch=master
     :target: https://coveralls.io/r/mozilla/funfactory
-.. image:: https://pypip.in/v/funfactory/badge.png
+.. image:: https://img.shields.io/pypi/v/funfactory.svg
     :target: https://crate.io/packages/funfactory
 
 Install


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20funfactory))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `funfactory`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.